### PR TITLE
Form does not crash, when saving without items

### DIFF
--- a/lib/one_to_many/groceries_list.ex
+++ b/lib/one_to_many/groceries_list.ex
@@ -19,7 +19,7 @@ defmodule OneToMany.GroceriesList do
     |> cast(params, [:email])
     |> validate_required([:email])
     |> validate_format(:email, ~r/@/)
-    |> cast_embed(:lines, with: &line_changeset/2)
+    |> cast_embed(:lines, with: &line_changeset/2, required: true )
   end
 
   def line_changeset(city, params) do


### PR DESCRIPTION
Hello Lost Kobra Kai,

thank you very much for this great example. 

While playing around with the example Repo I noticed a small error on your side, which crashes the form. In order to replicate the bug, please follow these steps.

1. Load the page
2. Enter a correct email
3. Press Save

Then the following error occurs: ** (Postgrex.Error) ERROR 23502 (not_null_violation) null value in column "lines" of relation "groceries_lists" violates not-null constraint

This can be avoided by adding `required: true` in the cast_embed for lines in the grocery changeset.

Have a nice weekend

Kind regards from a fresh elixir and phoenix newcomer.

PS: I do not know if it should be possible to save a grocery list without items. 
If this is not the case, there should be an error message saving an empty list and also when all items have been deleted, and you try resaving the form.