### PR TITLE
Use form directly, avoid using `f`

### DIFF
--- a/lib/one_to_many_web/live/list_live.ex
+++ b/lib/one_to_many_web/live/list_live.ex
@@ -5,8 +5,8 @@ defmodule OneToManyWeb.ListLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.simple_form :let={f} id="form" for={@form} phx-change="validate" phx-submit="submit" as="form">
-      <.input field={f[:email]} label="Email" />
+    <.simple_form id="form" for={@form} phx-change="validate" phx-submit="submit" as="form">
+      <.input field={@form[:email]} label="Email" />
 
       <fieldset class="flex flex-col gap-2">
         <legend>Groceries</legend>


### PR DESCRIPTION
According to [the docs](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1-using-the-for-attribute), this would be preferable, right?